### PR TITLE
use dockerComposeRunAndCaptureOutput

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ elifeLibrary {
         stage 'Build images', {
             checkout scm
             dockerComposeBuild(commit)
-            candidateVersion = dockerComposeRun(
+            candidateVersion = dockerComposeRunAndCaptureOutput(
                 "sciencebeam-alignment",
                 "./print_version.sh",
                 commit


### PR DESCRIPTION
use new `dockerComposeRunAndCaptureOutput` function before `dockerComposeRun` is changed to not capture output anymore