### PR TITLE
Added numpy 1.x support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
     "fuzzywuzzy>=0.18.0",
-    "numpy>=2.0.0",
+    "numpy>=1.20.0",
     "six>=1.17.0",
 ]
 
@@ -15,7 +15,7 @@ requires = [
   "setuptools>=61",
   "wheel",
   "Cython>=3.0",
-  "numpy>=2.2.6",
+  "numpy>=1.20.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/sciencebeam_alignment/align_fast_utils.pyx
+++ b/sciencebeam_alignment/align_fast_utils.pyx
@@ -4,6 +4,7 @@ cimport cython
 import numpy as pynp
 cimport numpy as cnp
 
+cnp.import_array()
 
 DEF MIN_INT = -2147483647
 


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/74

`delft` currently still requires numpy 1.x which caused a conflict. This should resolve that.